### PR TITLE
App Inspect Fixes

### DIFF
--- a/default/data/ui/views/attck_details.xml
+++ b/default/data/ui/views/attck_details.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>ATT&amp;CK Details</label>
   <fieldset submitButton="false">
     <input type="text" token="EventCode" searchWhenChanged="true">

--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -1,6 +1,5 @@
 # Application-level permissions
 []
-owner = admin
 access = read : [ * ], write : [ admin, sc_admin ]
 export = system
 


### PR DESCRIPTION
Fixed AppInspect Issue of Version in SimpleXML. Removed owner from default.meta to conform to spec.
Attached file is from appinspect run prior to PR.[wineventcodeapp-precert-20230106_02.txt](https://github.com/stressboi/splunk_wineventcode_secanalysis/files/10362157/wineventcodeapp-precert-20230106_02.txt)


